### PR TITLE
AO3-3880 Formatting tweaks for downloads

### DIFF
--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -83,7 +83,7 @@ class DownloadWriter
 
     ### Format-specific options
     # Mobi: ignore margins to keep it from padding on the left
-    mobi = download.file_type == "mobi" ? ['--mobi-ignore-margins'] : []
+    mobi = download.file_type == "mobi" ? ['--mobi-ignore-margins', '--remove-paragraph-spacing'] : []
     epub = download.file_type == "epub" ? ["--no-default-epub-cover"] : []
 
     [

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -82,9 +82,21 @@ class DownloadWriter
     end
 
     ### Format-specific options
-    # Mobi: ignore margins to keep it from padding on the left
-    mobi = download.file_type == "mobi" ? ['--mobi-ignore-margins', '--remove-paragraph-spacing'] : []
-    epub = download.file_type == "epub" ? ["--no-default-epub-cover"] : []
+    # Mobi: ignore margins to keep it from padding on the left, format
+    # paragraphs with a first-line indent and no verical margins, bold the
+    # labels in the metadata
+    # Note: We might want to use the path for a stylesheet instead of writing
+    # the CSS here, especially if we need more
+    # Epub: don't generate a cover image
+    mobi = if download.file_type == "mobi"
+             [
+               '--mobi-ignore-margins', '--remove-paragraph-spacing',
+               '--extra-css', '.meta dt { font-weight: bold; }'
+             ]
+           else
+             []
+           end
+    epub = download.file_type == "epub" ? ['--no-default-epub-cover'] : []
 
     [
       'ebook-convert',

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -84,6 +84,7 @@ class DownloadWriter
     ### Format-specific options
     # Mobi: ignore margins to keep it from padding on the left
     mobi = download.file_type == "mobi" ? ['--mobi-ignore-margins'] : []
+    epub = download.file_type == "epub" ? ["--no-default-epub-cover"] : []
 
     [
       'ebook-convert',
@@ -96,7 +97,7 @@ class DownloadWriter
       '--comments', meta[:summary],
       '--tags', meta[:tags],
       '--pubdate', meta[:pubdate]
-    ] + series + mobi
+    ] + series + mobi + epub
   end
 
   # A hash of the work data calibre needs


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3880

## Purpose

* Prevents Calibre from making covers for epubs
* Changes the paragraph formatting for mobi files to match the formatting on the current files
* Makes faux labels like "Warnings" and "Ratings" in the mobi metadata bold
