### PR TITLE
AO3-3880 Fix table of contents generation for mobi and epub

### DIFF
--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -108,7 +108,11 @@ class DownloadWriter
       '--authors', meta[:authors],
       '--comments', meta[:summary],
       '--tags', meta[:tags],
-      '--pubdate', meta[:pubdate]
+      '--pubdate', meta[:pubdate],
+      # XPaths for detecting chapters are overly specific to make sure we don't grab
+      # anything inputted by the user. First path is for single-chapter works,
+      # second for multi-chapter, and third for the preface and afterword
+      '--chapter', "//h:body/h:div[@id='chapters']/h:h2[@class='toc-heading'] | //h:body/h:div[@id='chapters']/h:div[@class='meta group']/h:h2[@class='heading'] | //h:body/h:div[@id='preface' or @id='afterword']/h:h2[@class='toc-heading']"
     ] + series + mobi + epub
   end
 

--- a/app/views/downloads/_download_afterword.html.erb
+++ b/app/views/downloads/_download_afterword.html.erb
@@ -1,23 +1,27 @@
-<% unless @work.endnotes.blank? && @work.approved_children.blank? %>
-  <div class="meta">
-    <% unless @work.endnotes.blank? %>
-      <div id="endnotes">
-        <p><%= ts("End Notes") %></p>
-        <blockquote class="userstuff"><%=raw sanitize_field(@work, :endnotes) %></blockquote>
-      </div>
-    <% end %>
+<div id="afterword">
+  <h2 class="toc-heading"><%= ts("Afterword") %></h2>
 
-    <% unless @work.approved_children.blank? %>
-      <dl>
-        <dt><%= ts('Works inspired by this one') %></dt>
-        <dd>
-          <%= @work.approved_related_works.where(:translation => false).map{|rw|
+  <% unless @work.endnotes.blank? && @work.approved_children.blank? %>
+    <div class="meta">
+      <% unless @work.endnotes.blank? %>
+        <div id="endnotes">
+          <p><%= ts("End Notes") %></p>
+          <blockquote class="userstuff"><%=raw sanitize_field(@work, :endnotes) %></blockquote>
+        </div>
+      <% end %>
+
+      <% unless @work.approved_children.blank? %>
+        <dl>
+          <dt><%= ts('Works inspired by this one') %></dt>
+          <dd>
+            <%= @work.approved_related_works.where(:translation => false).map{|rw|
 "#{link_to(rw.work.title.html_safe, work_url(rw.work))} #{ts('by')} #{byline(rw.work, only_path: false)}"}.join(",
 ").html_safe %>
-        </dd>
-      </dl>
-    <% end %>
-  </div>
-<% end %>
+          </dd>
+        </dl>
+      <% end %>
+    </div>
+  <% end %>
 
-<p class="message"><%= ts("Please") %> <%= link_to ts("drop by the archive and comment"), new_work_comment_url(@work) %> <%= ts("to let the author know if you enjoyed their work!") %></p>
+  <p class="message"><%= ts("Please") %> <%= link_to ts("drop by the archive and comment"), new_work_comment_url(@work) %> <%= ts("to let the author know if you enjoyed their work!") %></p>
+</div>

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -1,69 +1,73 @@
-<p class="message"><%= ts("Posted originally on the") %> <%= link_to ArchiveConfig.APP_NAME, root_url %>
+<div id="preface">
+  <h2 class="toc-heading"><%= ts("Preface") %></h2>
+
+  <p class="message"><%= ts("Posted originally on the") %> <%= link_to ArchiveConfig.APP_NAME, root_url %>
 <%= ts("at") %> <%= link_to work_url(@work), work_url(@work) %>.</p>
 
-<div class="meta">
-  <dl class="tags">
-    <% Tag::VISIBLE.each do |type| %>
-      <% tags = @work.tag_groups[type] %>
-      <% unless tags.blank? %>
-        <dt><%= type.constantize::NAME %>:</dt>
-        <dd><%= tags.map {|t| link_to(t.name, tag_url(t))}.join(", ").html_safe %></dd>
+  <div class="meta">
+    <dl class="tags">
+      <% Tag::VISIBLE.each do |type| %>
+        <% tags = @work.tag_groups[type] %>
+        <% unless tags.blank? %>
+          <dt><%= type.constantize::NAME %>:</dt>
+          <dd><%= tags.map {|t| link_to(t.name, tag_url(t))}.join(", ").html_safe %></dd>
+        <% end %>
       <% end %>
-    <% end %>
-    <% series_list = @work.serial_works.reject{ |sw| sw.series.nil? } %>
-    <% unless series_list.blank? %>
-      <dt><%= ts("Series") %>:</dt>
-      <dd><%= series_list.map {|s| "#{ts('Part')} #{s.position} #{ts('of')}
+      <% series_list = @work.serial_works.reject{ |sw| sw.series.nil? } %>
+      <% unless series_list.blank? %>
+        <dt><%= ts("Series") %>:</dt>
+        <dd><%= series_list.map {|s| "#{ts('Part')} #{s.position} #{ts('of')}
 #{link_to(s.series.title, series_url(s.series))}"}.join(", ").html_safe %></dd>
-    <% end %>
-    <% unless @work.approved_collections.empty? %>
-      <dt><%= ts('Collections') %>:</dt>
-      <dd><%= @work.approved_collections.map {|c| link_to c.title, collection_url(c)}.join(",
+      <% end %>
+      <% unless @work.approved_collections.empty? %>
+        <dt><%= ts('Collections') %>:</dt>
+        <dd><%= @work.approved_collections.map {|c| link_to c.title, collection_url(c)}.join(",
 ").html_safe %></dd>
-    <% end %>
-    <dt><%= ts("Stats") %>:</dt>
-    <dd>
-      <%= ts("Published") %>: <%= l(@work.first_chapter.published_at) %>
-      <% if @work.first_chapter.published_at < @work.revised_at.to_date %>
-        <%= @work.is_wip ? ts("Updated") : ts("Completed") %>: <%= l(@work.revised_at.to_date) %>
       <% end %>
-      <% if @work.chaptered? %>
-        <%= ts("Chapters") %>: <%= @work.chapter_total_display %>
-      <% end %>
-      <%= ts("Words") %>: <%= @work.word_count %>
-    </dd>
-  </dl>
-  <h1><%= @work.title.html_safe %></h1>
-  <div class="byline"><%= ts("by") %> <%= byline(@work, visibility: 'public', only_path: false) %></div>
-  <% unless @work.summary.blank? %>
-    <p><%= ts('Summary') %></p>
-    <blockquote class="userstuff"><%=raw sanitize_field(@work, :summary) %></blockquote>
-  <% end %>
-
-  <% unless @work.notes.blank? && @work.endnotes.blank? %>
-    <p><%= ts('Notes') %></p>
-    <% unless @work.notes.blank? %>
-      <blockquote class="userstuff"><%=raw sanitize_field(@work, :notes) %></blockquote>
-    <% end %>
-    <% unless @work.endnotes.blank? %>
-      <div class="endnote-link">
-        <%= ts("See the end of the work for") %> <% unless @work.notes.blank? %><%= ts("more") %><% end
-%> <%= link_to ts("notes"), "#endnotes" %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <% unless @work.parents.blank? %>
-    <dl>
-      <dt><%= ts('This work was inspired by') %></dt>
+      <dt><%= ts("Stats") %>:</dt>
       <dd>
-        <% parent_work_list = @work.parent_work_relationships.reject{ |wr| wr.parent.nil? } %>
-        <%= parent_work_list.map{ |rw| "#{link_to(rw.parent.title,
-               url_for(action: :show, controller: rw.parent_type.underscore.pluralize, id: rw.parent_id,
-                       only_path: false)) } #{ts('by')} #{byline(rw.parent, only_path: false)}" }.join(", ").html_safe %>
+        <%= ts("Published") %>: <%= l(@work.first_chapter.published_at) %>
+        <% if @work.first_chapter.published_at < @work.revised_at.to_date %>
+          <%= @work.is_wip ? ts("Updated") : ts("Completed") %>: <%= l(@work.revised_at.to_date) %>
+        <% end %>
+        <% if @work.chaptered? %>
+          <%= ts("Chapters") %>: <%= @work.chapter_total_display %>
+        <% end %>
+        <%= ts("Words") %>: <%= @work.word_count %>
       </dd>
     </dl>
-  <% end %>
+    <h1><%= @work.title.html_safe %></h1>
+    <div class="byline"><%= ts("by") %> <%= byline(@work, visibility: 'public', only_path: false) %></div>
+    <% unless @work.summary.blank? %>
+      <p><%= ts('Summary') %></p>
+      <blockquote class="userstuff"><%=raw sanitize_field(@work, :summary) %></blockquote>
+    <% end %>
 
+    <% unless @work.notes.blank? && @work.endnotes.blank? %>
+      <p><%= ts('Notes') %></p>
+      <% unless @work.notes.blank? %>
+        <blockquote class="userstuff"><%=raw sanitize_field(@work, :notes) %></blockquote>
+      <% end %>
+      <% unless @work.endnotes.blank? %>
+        <div class="endnote-link">
+          <%= ts("See the end of the work for") %> <% unless @work.notes.blank? %><%= ts("more") %><% end
+%> <%= link_to ts("notes"), "#endnotes" %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <% unless @work.parents.blank? %>
+      <dl>
+        <dt><%= ts('This work was inspired by') %></dt>
+        <dd>
+          <% parent_work_list = @work.parent_work_relationships.reject{ |wr| wr.parent.nil? } %>
+          <%= parent_work_list.map{ |rw| "#{link_to(rw.parent.title,
+                url_for(action: :show, controller: rw.parent_type.underscore.pluralize, id: rw.parent_id,
+                        only_path: false)) } #{ts('by')} #{byline(rw.parent, only_path: false)}" }.join(", ").html_safe %>
+        </dd>
+      </dl>
+    <% end %>
+
+  </div>
 </div>
 

--- a/app/views/downloads/show.html.erb
+++ b/app/views/downloads/show.html.erb
@@ -6,6 +6,7 @@
       <%= render 'downloads/download_chapter.html', :chapter => chapter %>
     <% end %>
   <% else %>
+    <h2 class="toc-heading"><%= @work.title.html_safe %></h2>
     <div class="userstuff">
       <%=raw sanitize_field(@chapters.first, :content) %>
     </div>

--- a/app/views/layouts/barebones.html.erb
+++ b/app/views/layouts/barebones.html.erb
@@ -10,16 +10,18 @@
     .meta h2 { font-size: 1.25em; text-align: center; }
     .meta h2 { page-break-before: always; }
     .meta .byline { text-align: center; }
-    .meta dl.tags { border: 1px solid;  padding: 1em; }
+    .meta dl.tags { border: 1px solid; padding: 1em; }
     .meta dd { margin: -1em 0 0 10em; }
     .meta .endnote-link { font-size: .8em; }
-    #chapters  { font-family: "Nimbus Roman No9 L", "Times New Roman", serif; padding: 1em; }
-    .userstuff  { font-family: "Nimbus Roman No9 L", "Times New Roman", serif; padding: 1em; }
+    #chapters { font-family: "Nimbus Roman No9 L", "Times New Roman", serif; padding: 1em; }
+    .userstuff { font-family: "Nimbus Roman No9 L", "Times New Roman", serif; padding: 1em; }
+    /* Invisible headings to help Calibre make a Table of Contents */
+    .toc-heading { display: none; }
   </style>
 </head>
 <body>
 
-<%= yield  %>
-    
+<%= yield %>
+
 </body>
 </html>


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-3880

## Purpose

* Override Calibre's default XPath for detecting chapters
* Add invisible h2s to HTML to set TOC section names

Note: The previous version of downloads did not generate a
proper TOC for mobi files -- it merely placed a list at the
top of the document. Now it has a proper TOC like epubs
always had.

Also note that everything starting with the h1 in
download_preface is now on a separate page in epub and mobi,
but is still considered part of the preface. The separate
happens because Calibre auto inserts them; this can be
overridden but was beyond the scope of this commit.
