### PR TITLE
AO3-3880 Ebook formatting changes, plus fix for series metadata

### DIFF
--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -125,7 +125,7 @@ class DownloadWriter
     }
     if work.series.exists?
       series = work.series.first
-      @metadata.merge(
+      @metadata.merge!(
         series_title: series.title,
         series_position: series.position_of(work).to_s
       )

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -82,20 +82,7 @@ class DownloadWriter
     end
 
     ### Format-specific options
-    # Mobi: ignore margins to keep it from padding on the left, format
-    # paragraphs with a first-line indent and no verical margins, bold the
-    # labels in the metadata
-    # Note: We might want to use the path for a stylesheet instead of writing
-    # the CSS here, especially if we need more
-    # Epub: don't generate a cover image
-    mobi = if download.file_type == "mobi"
-             [
-               '--mobi-ignore-margins', '--remove-paragraph-spacing',
-               '--extra-css', '.meta dt { font-weight: bold; }'
-             ]
-           else
-             []
-           end
+    # epub: don't generate a cover image
     epub = download.file_type == "epub" ? ['--no-default-epub-cover'] : []
 
     [
@@ -109,11 +96,12 @@ class DownloadWriter
       '--comments', meta[:summary],
       '--tags', meta[:tags],
       '--pubdate', meta[:pubdate],
+      '--extra-css', '/stylesheets/ebooks.css',
       # XPaths for detecting chapters are overly specific to make sure we don't grab
       # anything inputted by the user. First path is for single-chapter works,
       # second for multi-chapter, and third for the preface and afterword
       '--chapter', "//h:body/h:div[@id='chapters']/h:h2[@class='toc-heading'] | //h:body/h:div[@id='chapters']/h:div[@class='meta group']/h:h2[@class='heading'] | //h:body/h:div[@id='preface' or @id='afterword']/h:h2[@class='toc-heading']"
-    ] + series + mobi + epub
+    ] + series + epub
   end
 
   # A hash of the work data calibre needs

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -92,10 +92,14 @@ class DownloadWriter
       '--input-encoding', 'utf-8',
       '--use-auto-toc',
       '--title', meta[:title],
+      '--title-sort', meta[:sortable_title],
       '--authors', meta[:authors],
+      '--author-sort', meta[:sortable_authors],
       '--comments', meta[:summary],
       '--tags', meta[:tags],
       '--pubdate', meta[:pubdate],
+      '--publisher', ArchiveConfig.APP_NAME,
+      '--language', meta[:language],
       '--extra-css', '/stylesheets/ebooks.css',
       # XPaths for detecting chapters are overly specific to make sure we don't grab
       # anything inputted by the user. First path is for single-chapter works,
@@ -108,11 +112,16 @@ class DownloadWriter
   def meta
     return @metadata if @metadata
     @metadata = {
-      title:    work.title,
-      authors:  work.pseuds.pluck(:name).join("&"),
-      tags:     work.tags.pluck(:name).join(","),
-      pubdate:  work.revised_at.to_date.to_s,
-      summary:  work.summary
+      title:             work.title,
+      sortable_title:    work.sorted_title,
+      authors:           work.pseuds.pluck(:name).join("&"),
+      sortable_authors:  work.authors_to_sort_on,
+      # We add "Fanworks" because iBooks uses the first tag as the category and
+      # it would otherwise be the work's rating, which is weird
+      tags:              "Fanworks, " + work.tags.pluck(:name).join(","),
+      pubdate:           work.revised_at.to_date.to_s,
+      summary:           work.summary,
+      language:          work.language.short
     }
     if work.series.exists?
       series = work.series.first

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -100,7 +100,7 @@ class DownloadWriter
       '--pubdate', meta[:pubdate],
       '--publisher', ArchiveConfig.APP_NAME,
       '--language', meta[:language],
-      '--extra-css', '/stylesheets/ebooks.css',
+      '--extra-css', Rails.public_path.join('stylesheets/ebooks.css').to_s,
       # XPaths for detecting chapters are overly specific to make sure we don't grab
       # anything inputted by the user. First path is for single-chapter works,
       # second for multi-chapter, and third for the preface and afterword

--- a/app/models/download_writer.rb
+++ b/app/models/download_writer.rb
@@ -104,7 +104,7 @@ class DownloadWriter
       # XPaths for detecting chapters are overly specific to make sure we don't grab
       # anything inputted by the user. First path is for single-chapter works,
       # second for multi-chapter, and third for the preface and afterword
-      '--chapter', "//h:body/h:div[@id='chapters']/h:h2[@class='toc-heading'] | //h:body/h:div[@id='chapters']/h:div[@class='meta group']/h:h2[@class='heading'] | //h:body/h:div[@id='preface' or @id='afterword']/h:h2[@class='toc-heading']"
+      '--chapter', "//h:body/h:div[@id='chapters']/h:h2[@class='toc-heading'] | //h:body/h:div[@id='chapters']/h:div[@class='meta group']/h:h2[@class='heading'] | //h:body/h:div[@id='preface' or @id='afterword']/h:h2[@class='toc-heading']",
     ] + series + epub
   end
 

--- a/app/views/downloads/_download_preface.html.erb
+++ b/app/views/downloads/_download_preface.html.erb
@@ -1,8 +1,13 @@
 <div id="preface">
   <h2 class="toc-heading"><%= ts("Preface") %></h2>
 
-  <p class="message"><%= ts("Posted originally on the") %> <%= link_to ArchiveConfig.APP_NAME, root_url %>
-<%= ts("at") %> <%= link_to work_url(@work), work_url(@work) %>.</p>
+  <p class="message">
+    <b><%= @work.title.html_safe %></b><br/>
+    <%= ts("Posted originally on the %{archive_link} at %{work_url}.",
+          archive_link: link_to(ArchiveConfig.APP_NAME, root_url),
+          work_url: link_to(work_url(@work), work_url(@work))
+        ).html_safe %>
+  </p>
 
   <div class="meta">
     <dl class="tags">

--- a/public/stylesheets/ebooks.css
+++ b/public/stylesheets/ebooks.css
@@ -1,0 +1,18 @@
+.meta dl.tags {
+  border: none;
+  padding: 0;
+}
+
+.meta dl.tags > dt, .meta dl.tags > dd {
+  display: block;
+  margin: 0;
+}
+
+.meta dt {
+  font-weight: bold;
+}
+
+#chapters, .userstuff {
+  font-family: serif;
+  padding: 0;
+}


### PR DESCRIPTION
Standardize appearance of ebook formats
* No box or two-column display on meta for epubs
* No book-style paragraph formatting on mobis

Add more metadata
* title-sort: better alphabetization of titles with English articles in Kindle app and possibly Calibre, not so much iBooks
* author-sort: better alphabetization of authors (again, doesn't seem to apply in iBooks)
* tags: iBooks uses the first tag as the category, so we are adding 'Fanworks'
* language
* publisher

Make sure metadata includes series

Make ebook stylesheet work in development

Remove lingering code comment

Add title to the download preface